### PR TITLE
[Bugfix] 마이페이지 업적 보상 업데이트

### DIFF
--- a/src/components/MyPage/AchievementCard.tsx
+++ b/src/components/MyPage/AchievementCard.tsx
@@ -10,40 +10,21 @@ function AchievementCard({
 }: {
   achievement: AchievementCardProps;
 }) {
-  const {
-    level,
-    name,
-    total,
-    current,
-    description,
-    isMax,
-    onReward,
-    isRewarded,
-    resetReward,
-  } = achievement;
+  const { level, name, total, current, description, isMax, onReward } =
+    achievement;
 
   return (
     <div className="card achievement-card">
       {/* 아이콘과 레벨 - 좌측 */}
       {isMax ? (
         <span className="level-badge">
-          {!isRewarded ? (
-            <CustomButton
-              type="button"
-              className="level-up-button"
-              buttonText="보상 받기"
-              bgColor="var(--quatenary-color)"
-              onClick={onReward}
-            />
-          ) : (
-            <CustomButton
-              type="button"
-              className="level-up-button"
-              buttonText="보상 초기화"
-              bgColor="var(--quatenary-color)"
-              onClick={resetReward}
-            />
-          )}
+          <CustomButton
+            type="button"
+            className="level-up-button"
+            buttonText="보상 받기"
+            bgColor="var(--quatenary-color)"
+            onClick={onReward}
+          />
         </span>
       ) : (
         <span className="level-badge">

--- a/src/components/MyPage/AchievementCardList.tsx
+++ b/src/components/MyPage/AchievementCardList.tsx
@@ -8,16 +8,18 @@ import {
   getAchievementName,
 } from '@/utils/getAchievement';
 import AchievementCard from './AchievementCard';
+import { getAchievementByLevelType } from '@/lib/api';
 
 const AchievementCardList = ({
   daysSinceJoin,
   completedChallenges,
+  completedAchievements,
 }: {
   daysSinceJoin: number;
   completedChallenges: number;
+  completedAchievements: string[];
 }) => {
-  const { achievements, setAchievements, handleReward, handleResetReward } =
-    useHandleReward();
+  const { achievements, setAchievements, handleReward } = useHandleReward();
   const userExp = useUserStore((state) => state.exp) ?? 0;
   const userId = useUserStore((state) => state.uid) ?? null;
 
@@ -32,9 +34,18 @@ const AchievementCardList = ({
           };
 
           const fetchedAchievements = await Promise.all(
-            Object.entries(values).map(([type, value], index) => {
+            Object.entries(values).map(async ([type, value], index) => {
               const { current, level } = calculateAchievement(type, value);
               const maxValue = getAchievementMaxValue(type);
+
+              const nowCompletedAchievement = await getAchievementByLevelType(
+                level,
+                type as 'attendance_days' | 'exp' | 'completed_challenges'
+              );
+
+              const isOnList = nowCompletedAchievement
+                ? completedAchievements.includes(nowCompletedAchievement.id)
+                : false;
 
               return {
                 id: `${index + 1}`,
@@ -42,14 +53,11 @@ const AchievementCardList = ({
                 description: getAchievementDescription(type),
                 type,
                 total: maxValue,
-                current,
+                current: isOnList && current === maxValue ? 0 : current,
                 level,
-                isMax: current != 0 ? current === maxValue : false,
-                isRewarded: false,
+                isMax:
+                  !isOnList && current !== 0 ? current === maxValue : false,
                 onReward: () => handleReward(`${index + 1}`, level, type),
-                resetReward: () =>
-                  // 테스트용 업적/보상 초기화 함수
-                  handleResetReward(`${index + 1}`, level, type),
               };
             })
           );
@@ -60,6 +68,7 @@ const AchievementCardList = ({
         console.error('Error fetching achievements:', error);
       }
     };
+
     void fetchData();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [

--- a/src/hooks/useHandleReward.ts
+++ b/src/hooks/useHandleReward.ts
@@ -1,6 +1,4 @@
 import {
-  deleteUserAchievement,
-  deleteUserTitle,
   getAchievementByLevelType,
   getUserGem,
   insertUserAchievement,
@@ -30,33 +28,23 @@ export const useHandleReward = () => {
         const rewardGem = completedAchievement.reward_gem;
         const rewardTitle = completedAchievement.reward_title;
 
-        // 테스트 시 같은 업적 무한 추가를 막기 위해 삭제
-        await deleteUserAchievement(userId, completedAchievement.id);
-
         // 사용자 업적 테이블에 데이터 저장
         await insertUserAchievement(userId, completedAchievement.id);
 
         // Gem 보상 처리
         if (rewardGem) {
           const userGem = await getUserGem(userId);
+          const newUserGem = (userGem ?? 0) + rewardGem;
 
-          const newGem = (userGem ?? 0) + rewardGem;
-
-          // Gem 지급 (우선 무한 지급을 막기 위해 2500이 아닐 경우 2500으로 초기화)
-          if (userGem !== 2500) {
-            await updateUserGem(userId, 2500);
-            useUserStore.setState({ gem: 2500 });
-          } else {
-            await updateUserGem(userId, newGem);
-            useUserStore.setState({ gem: newGem });
+          // Gem 데이터 업데이트
+          if (userGem) {
+            await updateUserGem(userId, newUserGem);
+            useUserStore.setState({ gem: newUserGem });
           }
         }
 
         // 타이틀 보상 처리
         if (rewardTitle) {
-          // 테스트 시 같은 타이틀 무한 추가를 막기 위해 타이틀 삭제
-          await deleteUserTitle(userId, rewardTitle);
-
           await insertUserTitle(userId, rewardTitle);
         }
 
@@ -68,8 +56,7 @@ export const useHandleReward = () => {
                 ...achievement,
                 level: achievement.level,
                 current: 0, // 값 초기화
-                isMax: true, // 우선 테스트를 위해 true로 설정
-                isRewarded: true,
+                isMax: false,
               };
             }
             return achievement;
@@ -101,77 +88,9 @@ export const useHandleReward = () => {
     [userId] // userId가 변경될 때만 의존
   );
 
-  /* 테스트용 보상 초기화 함수 */
-  const handleResetReward = useCallback(
-    async (id: string, level: number, type: string) => {
-      try {
-        // 이미 업적을 가져온 경우 재사용
-        const completedAchievement = await getAchievementByLevelType(
-          level,
-          type as 'attendance_days' | 'exp' | 'completed_challenges'
-        );
-
-        if (!completedAchievement) return;
-
-        const rewardGem = completedAchievement.reward_gem;
-        const rewardTitle = completedAchievement.reward_title;
-
-        // 테스트 시 같은 업적 무한 추가를 막기 위해 삭제
-        await deleteUserAchievement(userId, completedAchievement.id);
-
-        // Gem 보상 리셋
-        if (rewardGem) {
-          const userGem = await getUserGem(userId);
-
-          const newGem = (userGem ?? 0) - rewardGem;
-
-          await updateUserGem(userId, newGem);
-          useUserStore.setState({ gem: newGem });
-        }
-
-        // 타이틀 보상 처리
-        if (rewardTitle) {
-          // 테스트 시 같은 타이틀 무한 추가를 막기 위해 타이틀 삭제
-          await deleteUserTitle(userId, rewardTitle);
-        }
-
-        // 상태를 최신 상태 기반으로 업데이트
-        setAchievements((prevAchievements) =>
-          prevAchievements.map((achievement) => {
-            if (achievement.id === id && achievement.isMax) {
-              return {
-                ...achievement,
-                level: achievement.level,
-                current: achievement.total, // 값 초기화
-                isRewarded: false,
-              };
-            }
-            return achievement;
-          })
-        );
-
-        console.log('보상 및 완료 챌린지 정보 삭제', {
-          achievement: completedAchievement,
-          rewardGem: rewardGem,
-          rewardTitle: rewardTitle,
-        });
-
-        // 보상 초기화 알림
-        await Swal.fire({
-          icon: 'success',
-          title: '업적 완료 초기화',
-        });
-      } catch (error) {
-        console.error('Error deleting user achievement:', error);
-      }
-    },
-    [userId] // userId가 변경될 때만 의존
-  );
-
   return {
     achievements,
     setAchievements,
     handleReward,
-    handleResetReward,
   };
 };

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -130,6 +130,21 @@ export const getAchievementByLevelType = async (
   return achievement;
 };
 
+export const getUserAchievements = async (userId: string) => {
+  // 유저 업적 데이터를 가져옴
+  const { data, error } = await supabase
+    .from('user_achievements')
+    .select('achievement_id')
+    .eq('user_id', userId);
+
+  if (error) {
+    console.error('Error fetching user achievements:', error.message);
+    throw error;
+  }
+
+  return data;
+};
+
 export const getUserGem = async (userId: string) => {
   // 유저의 보석 데이터를 가져옴
   const { data, error } = await supabase

--- a/src/pages/my-page/index.tsx
+++ b/src/pages/my-page/index.tsx
@@ -7,7 +7,7 @@ import ProfileInfo from '@/components/MyPage/ProfileInfo';
 import StatCardList from '@/components/MyPage/StatCardList';
 import Title from '@/layouts/title';
 import './style.css';
-import { getUserCompletedChallenge } from '@/lib/api';
+import { getUserAchievements, getUserCompletedChallenge } from '@/lib/api';
 import { useEffect } from 'react';
 import { useState } from 'react';
 
@@ -34,19 +34,27 @@ function MyPage() {
     : 0;
 
   const [completedChallenges, setCompletedChallenges] = useState<number>(0);
+  const [completedAchievements, setCompletedAchievements] = useState<string[]>(
+    []
+  );
 
   useEffect(() => {
-    const fetchCompletedChallenges = async () => {
+    const fetchData = async () => {
       try {
         const challenges = await getUserCompletedChallenge(userId);
+        const userCompletedAchievements = (
+          await getUserAchievements(userId)
+        ).map((achievement) => achievement.achievement_id);
+
         setCompletedChallenges(challenges?.length ?? 0);
+        setCompletedAchievements(userCompletedAchievements);
       } catch (error) {
         console.error('Error fetching completed challenges:', error);
       }
     };
 
     if (userId) {
-      void fetchCompletedChallenges();
+      void fetchData();
     }
   }, [userId]);
 
@@ -81,6 +89,7 @@ function MyPage() {
             <AchievementCardList
               daysSinceJoin={daysSinceJoin}
               completedChallenges={completedChallenges}
+              completedAchievements={completedAchievements}
             />
           </article>
         </section>

--- a/src/types/my-page/achievement.ts
+++ b/src/types/my-page/achievement.ts
@@ -8,8 +8,4 @@ export interface AchievementCardProps {
   description: string;
   isMax: boolean;
   onReward: () => void;
-
-  // 테스트용
-  isRewarded: boolean;
-  resetReward: () => void;
 }


### PR DESCRIPTION
- 테스트용 업정 보상 초기화 기능 제거
- 해당 레벨 업적이 이미 유저의 완료 업적에 있는 경우 새로고침 했을 때, 다시 보상받기가 나타나지 않음

#112

## PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR 체크리스트

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).

### PR 상세
마이페이지 편집 기능 구현 시 보유 칭호가 데이터베이스에서 사라졌다 생겼다 변동이 있으면 안 되는 상황이라
테스트용으로 구현했던 초기화 기능을 제거했습니다!

## 이슈

resolves #112 
